### PR TITLE
Fix Mouse Movement

### DIFF
--- a/CowBulls.py
+++ b/CowBulls.py
@@ -235,7 +235,6 @@ class CowBulls:
 
             if g.redraw:
                 self.display()
-                g.screen.blit(g.pointer, g.pos)
                 pygame.display.flip()
                 g.redraw = False
 

--- a/g.py
+++ b/g.py
@@ -8,7 +8,7 @@ images = {}
 
 def init():
     global redraw, screen, images
-    global scale, w, h, pointer, pos
+    global scale, w, h, pos
     global INPUT_SIZE, DISP_SIZE, DIALPAD
     global ATTEMPT, XGAP, DKP
 
@@ -26,8 +26,6 @@ def init():
     Y_INIT = (h - 900 * scale) / 2
 
     pos = pygame.mouse.get_pos()
-    pointer = images['data/pointer.png']
-    pygame.mouse.set_visible(False)
     MARGIN = 10 * scale
     INPUT_SIZE = 75 * scale
     DISP_SIZE = 55 * scale


### PR DESCRIPTION
The cursor is separately drawn in the activity. As a result, the user's cursor is replaced with the cursor drawn in the activity. As the activity is locked at 20 fps, the mouse movement appears to be slow. This commit fixes it by removing the code which draws the cursor.

Fixes #19 